### PR TITLE
Cortex validation: Change case conversion of error contexts

### DIFF
--- a/src/validation.php
+++ b/src/validation.php
@@ -141,7 +141,7 @@ class Validation extends \Prefab {
 		$level_cmp = ($op[0]=='<') ? -1 : (($op[0]=='>') ? 1 : 0);
 		$level+=($op=='<=') ? 1 : (($op=='>=') ? -1 : 0);
 		$valid = true;
-		$context_error = strtolower(str_replace('\\','.',get_class($mapper)));
+		$context_error = implode('.',array_map('lcfirst',explode('\\',get_class($mapper))));
 		$gump_conf = [
 			'copy_fields' => [],
 			'get_fields' => [],


### PR DESCRIPTION
Instead of convert the whole string of error contexts to lowercase, only change the first letter of namespace / class

old: MyModels\FileLocation = mymodels.filelocation

new: MyModels\FileLocation = myModels.fileLocation

This corresponds to standard of var names in php (camel case with first letter in lowercase)